### PR TITLE
Martin dev

### DIFF
--- a/src/main/java/com/github/martinsawicki/chainable/Chainable.java
+++ b/src/main/java/com/github/martinsawicki/chainable/Chainable.java
@@ -434,8 +434,8 @@ public interface Chainable<T> extends Iterable<T> {
      * check against an item already seen before.
      * @param childExtractor
      * @return resulting chain
-     * @see #breadthFirstUntil(Function, Function)
-     * @see #breadthFirstWhile(Function, Function)
+     * @see #breadthFirstNotBelow(Function, Function)
+     * @see #breadthFirstAsLongAs(Function, Function)
      * @see #depthFirst(Function)
      */
     default Chainable<T> breadthFirst(Function<T, Iterable<T>> childExtractor) {
@@ -456,29 +456,29 @@ public interface Chainable<T> extends Iterable<T> {
      * @param childExtractor
      * @param condition
      * @return resulting chain
-     * @see #breadthFirstWhile(Function, Function)
+     * @see #breadthFirstAsLongAs(Function, Function)
      * @see #breadthFirst(Function)
      * @see #depthFirst(Function)
      */
-    default Chainable<T> breadthFirstUntil(Function<T, Iterable<T>> childExtractor, Function<T, Boolean> condition) {
-        return Chainables.breadthFirstUntil(this, childExtractor, condition);
+    default Chainable<T> breadthFirstNotBelow(Function<T, Iterable<T>> childExtractor, Function<T, Boolean> condition) {
+        return Chainables.breadthFirstNotBelow(this, childExtractor, condition);
     }
 
     /**
-     * Traverses the items in this chain in a breadth-first order as if it's a tree, where for each item, those of its children returned by the specified
-     * {@code childTraverser} are appended to the end of the chain that satisfy the specified {@code condition}.
+     * Traverses the items in this chain in a breadth-first order as if it's a tree, where for each item, only those of its children returned by
+     * the specified {@code childTraverser} are appended to the end of the chain that satisfy the specified {@code condition}.
      * <p>
      * It can be thought of trimming the breadth-first traversal of a hypothetical tree right above the level of each item satisfying
      * the {@code condition}, but continuing with other items in the chain.
      * @param childExtractor
      * @param condition
      * @return resulting chain
-     * @see #breadthFirstUntil(Function, Function)
+     * @see #breadthFirstNotBelow(Function, Function)
      * @see #breadthFirst(Function)
      * @see #depthFirst(Function)
      */
-    default Chainable<T> breadthFirstWhile(Function<T, Iterable<T>> childExtractor, Function<T, Boolean> condition) {
-        return Chainables.breadthFirstWhile(this, childExtractor, condition);
+    default Chainable<T> breadthFirstAsLongAs(Function<T, Iterable<T>> childExtractor, Function<T, Boolean> condition) {
+        return Chainables.breadthFirstAsLongAs(this, childExtractor, condition);
     }
 
     /**

--- a/src/main/java/com/github/martinsawicki/chainable/Chainable.java
+++ b/src/main/java/com/github/martinsawicki/chainable/Chainable.java
@@ -460,7 +460,7 @@ public interface Chainable<T> extends Iterable<T> {
      * @see #breadthFirst(Function)
      * @see #depthFirst(Function)
      */
-    default Chainable<T> breadthFirstNotBelow(Function<T, Iterable<T>> childExtractor, Function<T, Boolean> condition) {
+    default Chainable<T> breadthFirstNotBelow(Function<T, Iterable<T>> childExtractor, Predicate<T> condition) {
         return Chainables.breadthFirstNotBelow(this, childExtractor, condition);
     }
 
@@ -477,7 +477,7 @@ public interface Chainable<T> extends Iterable<T> {
      * @see #breadthFirst(Function)
      * @see #depthFirst(Function)
      */
-    default Chainable<T> breadthFirstAsLongAs(Function<T, Iterable<T>> childExtractor, Function<T, Boolean> condition) {
+    default Chainable<T> breadthFirstAsLongAs(Function<T, Iterable<T>> childExtractor, Predicate<T> condition) {
         return Chainables.breadthFirstAsLongAs(this, childExtractor, condition);
     }
 
@@ -688,6 +688,26 @@ public interface Chainable<T> extends Iterable<T> {
      */
     default Chainable<T> depthFirst(Function<T, Iterable<T>> childExtractor) {
         return Chainables.depthFirst(this, childExtractor);
+    }
+
+    /**
+     * Traverses the items in this chain in a depth-first order as if it were a tree, where for each item, the items output by the specified
+     * {@code childExtractor} applied to it are inserted at the beginning of the chain, <i>up to and including</i> the parent item that satisfies
+     * the specified {@code condition}, but not its descendants that would be otherwise returned by the {@code childExtractor}.
+     * <p>
+     * It can be thought of trimming the depth-first traversal of a hypothetical tree right below the level of the item satisfying
+     * the {@code condition}, but continuing with other items in the chain.
+     * <p>
+     * To indicate the absence of children for an item, the child extractor may output {@code null}.
+     * <p>
+     * The traversal protects against potential cycles by not visiting items that satisfy the equality ({@code equals()}) check against
+     * an item already seen before.
+     * @param childExtractor
+     * @param condition
+     * @return resulting chain
+     */
+    default Chainable<T> depthFirstNotBelow(Function<T, Iterable<T>> childExtractor, Predicate<T> condition) {
+        return Chainables.depthFirstNotBelow(this, childExtractor, condition);
     }
 
     /**

--- a/src/main/java/com/github/martinsawicki/chainable/ChainableTree.java
+++ b/src/main/java/com/github/martinsawicki/chainable/ChainableTree.java
@@ -93,4 +93,13 @@ public interface ChainableTree<T> {
     static <T> ChainableTree<T> withValue(T value) {
         return new ChainableTreeImpl<T>(value);
     }
+
+    /**
+     * Extracts the chain of values from the specified {@code trees}.
+     * @param trees the trees to extract values from
+     * @return a chain of values from the specified {@code trees}
+     */
+    static <T> Chainable<T> values(Iterable<ChainableTree<T>> trees) {
+        return ChainableTrees.values(trees);
+    }
 }

--- a/src/main/java/com/github/martinsawicki/chainable/ChainableTree.java
+++ b/src/main/java/com/github/martinsawicki/chainable/ChainableTree.java
@@ -80,6 +80,12 @@ public interface ChainableTree<T> {
     ChainableTree<T> withChildValues(T... childValues);
 
     /**
+     * Removes all children from this tree.
+     * @return self
+     */
+    ChainableTree<T> withoutChildren();
+
+    /**
      * Creates a new tree (a single node) with the specified wrapped {@code value}.
      * @param value the value to wrap in the new tree node
      * @return

--- a/src/main/java/com/github/martinsawicki/chainable/ChainableTree.java
+++ b/src/main/java/com/github/martinsawicki/chainable/ChainableTree.java
@@ -4,6 +4,8 @@
  */
 package com.github.martinsawicki.chainable;
 
+import java.util.function.Function;
+
 import com.github.martinsawicki.chainable.ChainableTrees.ChainableTreeImpl;
 
 /**
@@ -53,6 +55,29 @@ public interface ChainableTree<T> {
      */
     @SuppressWarnings("unchecked")
     ChainableTree<T> withChildren(ChainableTree<T>... children);
+
+    /**
+     * Wraps the values generated lazily by the specified {@code childExtractor} into child trees of this tree, appending them to the existing
+     * children of this tree.
+     * @param childExtractor a function that returns child values based on the parent value it is being fed
+     * @return self
+     */
+    ChainableTree<T> withChildValueExtractor(Function<T, Iterable<T>> childExtractor);
+
+    /**
+     * Appends trees with the specified wrapped {@code childValues} to the children of this tree.
+     * @param childValues child values to wrap in trees and appends to the children of this tree
+     * @return self
+     */
+    ChainableTree<T> withChildValues(Iterable<T> childValues);
+
+    /**
+     * Appends trees with the specified wrapped {@code childValues} to the children of this tree.
+     * @param childValues child values to wrap in trees and appends to the children of this tree
+     * @return self
+     */
+    @SuppressWarnings("unchecked")
+    ChainableTree<T> withChildValues(T... childValues);
 
     /**
      * Creates a new tree (a single node) with the specified wrapped {@code value}.

--- a/src/main/java/com/github/martinsawicki/chainable/ChainableTrees.java
+++ b/src/main/java/com/github/martinsawicki/chainable/ChainableTrees.java
@@ -84,6 +84,11 @@ public abstract class ChainableTrees {
             }
         }
 
+        @Override
+        public ChainableTree<T> withoutChildren() {
+            return this.withChildren((Iterable<ChainableTree<T>>) null);
+        }
+
         ChainableTreeImpl<T> withParent(ChainableTree<T> parent) {
             this.parent = parent;
             return this;

--- a/src/main/java/com/github/martinsawicki/chainable/ChainableTrees.java
+++ b/src/main/java/com/github/martinsawicki/chainable/ChainableTrees.java
@@ -5,6 +5,7 @@
 package com.github.martinsawicki.chainable;
 
 import java.util.ArrayList;
+import java.util.function.Function;
 
 /**
  * This is the source of all the static methods underlying the default implementation of {@link ChainableTree} as well as some other conveniences.
@@ -57,6 +58,30 @@ public abstract class ChainableTrees {
         @Override
         public ChainableTreeImpl<T> withChildren(ChainableTree<T>... children) {
             return this.withChildren(Chainable.from(children));
+        }
+
+        @Override
+        public ChainableTreeImpl<T> withChildValues(Iterable<T> childValues) {
+            return this.withChildren(Chainable
+                    .from(childValues)
+                    .transform(c -> ChainableTree.withValue(c)));
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public ChainableTreeImpl<T> withChildValues(T... childValues) {
+            return this.withChildValues(Chainable.from(childValues));
+        }
+
+        @Override
+        public ChainableTreeImpl<T> withChildValueExtractor(Function<T, Iterable<T>> childExtractor) {
+            if (childExtractor != null) {
+                return this.withChildren(Chainable
+                        .from(childExtractor.apply(this.inner()))
+                        .transform(c -> ChainableTree.withValue(c).withChildValueExtractor(childExtractor)));
+            } else {
+                return this;
+            }
         }
 
         ChainableTreeImpl<T> withParent(ChainableTree<T> parent) {

--- a/src/main/java/com/github/martinsawicki/chainable/Chainables.java
+++ b/src/main/java/com/github/martinsawicki/chainable/Chainables.java
@@ -559,9 +559,8 @@ public final class Chainables {
     public static <T> Chainable<T> breadthFirstNotBelow(
             Iterable<T> items,
             Function<T, Iterable<T>> childTraverser,
-            Function<T, Boolean> condition) {
-        final Function<T, Boolean> appliedCondition = (condition != null) ? condition : (o -> false);
-        return breadthFirst(items, o -> Boolean.FALSE.equals(appliedCondition.apply(o)) ? childTraverser.apply(o) : Chainable.empty());
+            Predicate<T> condition) {
+        return notBelow(items, childTraverser, condition, true);
     }
 
     /**
@@ -574,9 +573,9 @@ public final class Chainables {
     public static <T> Chainable<T> breadthFirstAsLongAs(
             Iterable<T> items,
             Function<T, Iterable<T>> childTraverser,
-            Function<T, Boolean> condition) {
-        final Function<T, Boolean> appliedCondition = (condition != null) ? condition : (o -> true);
-        return breadthFirst(items, o -> Chainables.whereEither(childTraverser.apply(o), c -> Boolean.TRUE.equals(appliedCondition.apply(c))));
+            Predicate<T> condition) {
+        final Predicate<T> appliedCondition = (condition != null) ? condition : (o -> true);
+        return breadthFirst(items, o -> Chainables.whereEither(childTraverser.apply(o), c -> Boolean.TRUE.equals(appliedCondition.test(c))));
     }
 
     /**
@@ -1085,6 +1084,20 @@ public final class Chainables {
      */
     public static <T> Chainable<T> depthFirst(Iterable<T> items, Function<T, Iterable<T>> childTraverser) {
         return traverse(items, childTraverser, false);
+    }
+
+    /**
+     * @param items
+     * @param childTraverser
+     * @param condition
+     * @return
+     * @see Chainable#depthFirstNotBelow(Function, Predicate)
+     */
+    public static <T> Chainable<T> depthFirstNotBelow(
+            Iterable<T> items,
+            Function<T, Iterable<T>> childTraverser,
+            Predicate<T> condition) {
+        return notBelow(items, childTraverser, condition, false);
     }
 
     /**
@@ -1908,6 +1921,15 @@ public final class Chainables {
      */
     public static <T> Chainable<T> notBeforeEquals(Iterable<T> items, T item) {
         return notBefore(items, (Predicate<T>)(o -> o == item));
+    }
+
+    private static <T> Chainable<T> notBelow(
+            Iterable<T> items,
+            Function<T, Iterable<T>> childTraverser,
+            Predicate<T> condition,
+            boolean breadthFirst) {
+        final Predicate<T> appliedCondition = (condition != null) ? condition : (o -> false);
+        return traverse(items, o -> Boolean.FALSE.equals(appliedCondition.test(o)) ? childTraverser.apply(o) : Chainable.empty(), breadthFirst);
     }
 
     /**

--- a/src/main/java/com/github/martinsawicki/chainable/Chainables.java
+++ b/src/main/java/com/github/martinsawicki/chainable/Chainables.java
@@ -554,9 +554,9 @@ public final class Chainables {
      * @param childTraverser
      * @param condition
      * @return
-     * @see Chainable#breadthFirstUntil(Function, Function)
+     * @see Chainable#breadthFirstNotBelow(Function, Function)
      */
-    public static <T> Chainable<T> breadthFirstUntil(
+    public static <T> Chainable<T> breadthFirstNotBelow(
             Iterable<T> items,
             Function<T, Iterable<T>> childTraverser,
             Function<T, Boolean> condition) {
@@ -569,9 +569,9 @@ public final class Chainables {
      * @param childTraverser
      * @param condition
      * @return
-     * @see Chainable#breadthFirstWhile(Function, Function)
+     * @see Chainable#breadthFirstAsLongAs(Function, Function)
      */
-    public static <T> Chainable<T> breadthFirstWhile(
+    public static <T> Chainable<T> breadthFirstAsLongAs(
             Iterable<T> items,
             Function<T, Iterable<T>> childTraverser,
             Function<T, Boolean> condition) {

--- a/src/test/java/com/github/martinsawicki/chainable/ChainableTest.java
+++ b/src/test/java/com/github/martinsawicki/chainable/ChainableTest.java
@@ -272,7 +272,7 @@ public class ChainableTest {
                 .join(",");
 
         // When
-        String actual = roots.breadthFirstUntil(
+        String actual = roots.breadthFirstNotBelow(
                 s -> roots.transform(o -> s + o),
                 s -> s.length() == 2)
                 .join(",");
@@ -289,7 +289,7 @@ public class ChainableTest {
         String expected = String.join(",", expectedResults);
 
         // When
-        String actual = roots.breadthFirstWhile(
+        String actual = roots.breadthFirstAsLongAs(
                 s -> roots.transform(o -> s + o),
                 s -> s.length() < 3)
                 .join(",");

--- a/src/test/java/com/github/martinsawicki/chainable/ChainableTest.java
+++ b/src/test/java/com/github/martinsawicki/chainable/ChainableTest.java
@@ -264,7 +264,7 @@ public class ChainableTest {
     }
 
     @Test
-    public void testBreadthFirstUntil() {
+    public void testBreadthFirstNotBelow() {
         // Given
         Chainable<String> roots = Chainable.from("a", "b", "c");
         String expected = Chainable
@@ -282,7 +282,7 @@ public class ChainableTest {
     }
 
     @Test
-    public void testBreadthFirstWhile() {
+    public void testBreadthFirstAsLongAs() {
         // Given
         Chainable<String> roots = Chainable.from("a", "b", "c");
         Chainable<String> expectedResults = Chainable.from("a", "b", "c", "aa", "ab", "ac", "ba", "bb", "bc", "ca", "cb", "cc");
@@ -514,6 +514,21 @@ public class ChainableTest {
 
         // Then
         assertEquals(expectedDepthFirst, actualDepthFirst);
+    }
+
+    @Test
+    public void testDepthFirstNotBelow() {
+        // Given
+        final int depth = 4;
+        Chainable<String> initial = Chainable.from("1");
+        Function<String, Iterable<String>> childExtractor = (s) -> (s.length() < (depth - 1)  * 2) ? Chainable.from(s + ".1", s + ".2") : null;
+        String expected = "1, 1.1, 1.1.1, 1.1.2, 1.2, 1.2.1, 1.2.2";
+
+        // When
+        String actual = initial.depthFirstNotBelow(childExtractor, i -> i.length() == 5).join(", ");
+
+        // Then
+        assertEquals(expected, actual);
     }
 
     @Test

--- a/src/test/java/com/github/martinsawicki/chainable/ChainableTreeTest.java
+++ b/src/test/java/com/github/martinsawicki/chainable/ChainableTreeTest.java
@@ -44,4 +44,24 @@ public class ChainableTreeTest {
         assertEquals(firstRunLength + secondRunLength, root.children().count());
         assertEquals(actual1, actual2); // Ensure children are evaluated only once and cached from thereon
     }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    // TODO: Make this richer
+    public void testWithoutChildren() {
+        // Given
+        ChainableTree<String> tree = ChainableTree.withValue("A").withChildren(
+                ChainableTree.withValue("A.1")
+                    .withChildren(
+                            ChainableTree.withValue("A.1.1"),
+                            ChainableTree.withValue("A.1.2")),
+                ChainableTree.withValue("A.2")
+                    .withChildren(
+                            ChainableTree.withValue("A.2.1"),
+                            ChainableTree.withValue("A.2.2")));
+
+        // When / Then
+        assertEquals(2, tree.children().count());
+        assertEquals(0, tree.withoutChildren().children().count());
+    }
 }


### PR DESCRIPTION
`ChainableTree`:
- `withChildValues()`, `withChildValueExtractor()`
- `withoutChildren()`
- `depthFirstNotBelow()`
- `values()`

`Chainable`:
- renaming `breadthFirstUntil()` as `breadthFirstNotBelow()`
- renaming `breadthFirstWhile()' as `breadthFirstAsLongAs()`